### PR TITLE
build(deps): update rust crate minijinja-cabi to v2.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,8 +16,8 @@ checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
 
 [[package]]
 name = "minijinja"
-version = "2.8.0"
-source = "git+https://github.com/maxbrunet/minijinja.git?rev=3c6bdd0d6920dd074c778f70ed3662aa6d04cf99#3c6bdd0d6920dd074c778f70ed3662aa6d04cf99"
+version = "2.9.0"
+source = "git+https://github.com/mitsuhiko/minijinja.git?tag=2.9.0#16adfd00e0453ea308274f1c8a1c9d31055673c8"
 dependencies = [
  "aho-corasick",
  "memo-map",
@@ -27,8 +27,8 @@ dependencies = [
 
 [[package]]
 name = "minijinja-cabi"
-version = "2.8.0"
-source = "git+https://github.com/maxbrunet/minijinja.git?rev=3c6bdd0d6920dd074c778f70ed3662aa6d04cf99#3c6bdd0d6920dd074c778f70ed3662aa6d04cf99"
+version = "2.9.0"
+source = "git+https://github.com/mitsuhiko/minijinja.git?tag=2.9.0#16adfd00e0453ea308274f1c8a1c9d31055673c8"
 dependencies = [
  "minijinja",
 ]
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "self_cell"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2fdfc24bc566f839a2da4c4295b82db7d25a24253867d5c64355abb5799bdbe"
+checksum = "0f7d95a54511e0c7be3f51e8867aa8cf35148d7b9445d44de2f943e2b206e749"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-minijinja-cabi = { git = "https://github.com/maxbrunet/minijinja.git", rev = "3c6bdd0d6920dd074c778f70ed3662aa6d04cf99" }
+minijinja-cabi = { git = "https://github.com/mitsuhiko/minijinja.git", tag = "2.9.0" }
 
 [profile.release]
 lto = true


### PR DESCRIPTION
[mitsuhiko/minijinja@`2.9.0` (release)](https://github.com/mitsuhiko/minijinja/releases/tag/2.9.0)